### PR TITLE
Programmatically configured bot

### DIFF
--- a/_drafts/programatically-configured-bots.md
+++ b/_drafts/programatically-configured-bots.md
@@ -1,0 +1,63 @@
+---
+state: In Progress
+---
+
+# Progmatic configuration of bots
+
+A progmatically configured hubot would allow for developers to write a Javascript-VM-language-of-choice file to build their bot step-by-step, and have full control of the order of that scripts are loaded, in addition to allowing customizing express, the VM, etc.
+
+## Motivation
+
+The only way you can have hubot run your code is by having it in the `scripts`, or specified in `external-scripts.json` (and the deprecated `hubot-scripts.json`). This means there is not an obvious place to inject framework-level customizations (like an install-specific `robot` helper function).
+
+The current workaround is to name script files in a way that they are more likely to be loaded first. Consider:
+
+```coffeescript
+# scripts/0-init.coffee
+module.exports = (robot) ->
+  robot.myawesomehelper = () ->
+    # insert awesome code here
+
+# scripts/whatever.coffee
+module.exports = (robot) ->
+  robot.myawesomehelper()
+```
+
+There are some tools that need to be loaded as soon as possible to instrument as much as possible, such as NewRelic. There is no way currently to load that any sooner. [hubot#847](https://github.com/github/hubot/issues/847) is one example of this
+
+Hubot includes an instance of [expressjs](https://expressjs.com/) in it, for convenience in integrating with other services, and also because some adapters need it. Since it is a HTTP server, there are an infinite number of ways to configure it, and it is impossible to accomodate all of them. There have been a number of PRs and requests over the year to allow customization of some of its expressjs, and have involved adding an increasing number of environment variables to control the behavior. An experienced expressjs user coming onto hubot would not be able to customize the server in a way they would be used to. The specifics of allowing this are worth having its own evolution proposal, but a programatic launch of hubot would be a pre-requisite of it.
+
+Lastly, there is a fair amount of scaffolding to get hubot running. Programatic launching of hubot would allow for a single-file example hubot. This would make for a great getting started example, and also obviate the need for a generator which has been progmatic in the past.
+
+
+## Proposed solution
+
+> Describe your solution to the problem. Provide examples and describe how they work. Show how your solution is better than current workarounds.
+
+TODO
+
+- refactor `Robot` constructor to not use positional arguments
+
+## Detailed design
+
+> Describe the design of the solution in detail. The detail in this section should be sufficient for someone who is *not* one of the authors to be able to reasonably implement the feature.
+
+TODO
+
+- update internals to remove assumptions about startup (ie not from bin/hubot)
+  - https://github.com/github/hubot/pull/1110 is a start
+- update APIs to easier, more obvious how they work, etc when running from a single file
+  - probably means `Robot` taking key/values, rather than positional
+   
+
+## Backward compatibility
+
+> Describe how this change affects compatibility with existing community packages. Will they break? Will they produce different behavior? If "yes" to either of these, is it possible to support the old behavior alongside the new behavior? Can scripts be written in a way that they work before and after this change?
+
+Changing the constructor to use an Object of options would break compatability. It should be possible to detect if the first argument is an Object to use the new style, or use the old positional arguments.
+
+`Robot`'s contrusctor might not even be a public API currently, but it's pretty likely something out there (test helpers?) use it in its current form.
+
+## Alternatives considered
+
+> Describe alternative approaches to addressing the same problem, and why you chose this approach instead.

--- a/_drafts/programatically-configured-bots.md
+++ b/_drafts/programatically-configured-bots.md
@@ -23,9 +23,9 @@ module.exports = (robot) ->
   robot.myawesomehelper()
 ```
 
-Some tools need to be initialized as soon as possible to instrument as much as possible. There's no easy way to load that any sooner than when Hubot starts loading scripts. [hubot#847](https://github.com/github/hubot/issues/847) is one example of this, where the user wants to instrument Hubot with [New Relic](https://newrelic.com/), but it can't be loaded soon enough to be effective.
+Some tools require initialization as soon as possible to instrument as much as possible. There's no easy way to load that any sooner than when Hubot starts loading scripts. [hubot#847](https://github.com/github/hubot/issues/847) is one example of this, where the user wants to instrument Hubot with [New Relic](https://newrelic.com/), but it can't load soon enough to be effective.
 
-Hubot includes an instance of [Express](https://expressjs.com/) in it, for convenience in integrating with other services, and also because some adapters need it. Express is itself very configurable, and it's difficult to accommodate that configurability from Hubot. There have been PRs and requests over the year to allow customization of some of its Express, and have involved adding an increasing number of environment variables to control the behavior. An experienced Express user starting with Hubot would not be able to configure the server in all the ways they are familiar with. It's worth a separate evolution proposal for more specifics on that, but a programmatic launch of hubot would be a prerequisite of it.
+Hubot includes an instance of [Express](https://expressjs.com/) in it, for convenience in integrating with other services, and also because some adapters need it. Express is has innumerable configuration options, and it's difficult to accommodate that configurability from Hubot. There have been PRs and requests over the year to allow customization of some of its Express, and have involved adding an increasing number of environment variables to control the behavior. An experienced Express user starting with Hubot would not be able to configure the server in all the ways they are familiar with. It's worth a separate evolution proposal for more specifics on that, but a programmatic launch of hubot would be a prerequisite of it.
 
 Lastly, there is a fair amount of scaffolding to get hubot running. Programmatic launching of hubot would allow for a single-file example hubot. This would make for a great getting started example, and also obviate the need for a generator which has been programmatic in the past.
 
@@ -33,7 +33,10 @@ Lastly, there is a fair amount of scaffolding to get hubot running. Programmatic
 
 > Describe your solution to the problem. Provide examples and describe how they work. Show how your solution is better than current workarounds.
 
-TODO
+Add a public API for using hubot as a module, in addition to the `bin/hubot` launcher. `bin/hubot` will continue to work for basic usage of loading scripts from a local directory and from npm modules, and using `hubot` as a module will be an option for more advanced usage, including controlling load-order, extending hubot, or anything else you can do with Javascript.
+
+
+Here is a an example `index.coffee` for using hubot as a module to with similar behavior to `bin/hubot`:
 
 ```coffeescript
 Hubot   = require 'hubot'
@@ -47,7 +50,7 @@ robot.alias = '/'
 
 # wait for adapter to connect, since it might change robot.name at runtime,
 # like robot name
-robot.adapter.on 'connected', ->
+robot.adapter.once 'connected', ->
 
   # require external hubot scripts
   robot.loadScriptPackage require('hubot-help')
@@ -67,8 +70,7 @@ robot.run()
 
 Open questions to answer:
 
-- is there any need for the bin/hubot launcher? Perhaps it could be useful for handling some of the logistics of
-- should `loadScriptPackage` take a string to require, or expect a function? if it takes a function, that implies something that is more general
+- should `loadScriptPackage` take a string to require, or expect a function? if it takes a function, that could be re-used more generally
 
 ## Detailed design
 
@@ -77,19 +79,23 @@ Open questions to answer:
 TODO
 
 - update internals to remove assumptions about startup (ie not from bin/hubot)
-  - https://github.com/github/hubot/pull/1110 is a start
+  - https://github.com/github/hubot/pull/1110 is a first attempt at it
+  - it is mostly moving a lot of logic from `bin/hubot` into the `hubot` so it can be re-used
 - update APIs to easier, more obvious how they work, etc when running from a single file
-  - probably means `Robot` taking key/values, rather than positional
+  - probably means `Robot` taking key/values, rather than positional arguments
   - make arguments/options to `Robot` constructor optional, but validate required options when `run`ning
+- update documentation for module usage
 
 ## Backward compatibility
 
 > Describe how this change affects compatibility with existing community packages. Will they break? Will they produce different behavior? If "yes" to either of these, is it possible to support the old behavior alongside the new behavior? Can scripts be written in a way that they work before and after this change?
 
-Changing the constructor to use an Object of options would break compatibility. It should be possible to detect if the first argument is an Object to use the new style, or use the old positional arguments.
+Changing the constructor to use an Object of options would break compatibility. It should be possible to detect if the first argument is an Object to use the new style, or use the old positional arguments to preserve existing behavior though.
 
 `Robot`'s constructor might not even be a public API, but it's likely there is code out there (test helpers?) using it in its current form.
 
 ## Alternatives considered
 
 > Describe alternative approaches to addressing the same problem, and why you chose this approach instead.
+
+Considered having the `bin/hubot` launcher interact with a `index.coffee` or `index.js`. It wasn't clear how that would work, and just running `index.coffee` or `index.js` makes more sense if you are familiar with running javascript projects.

--- a/_drafts/programatically-configured-bots.md
+++ b/_drafts/programatically-configured-bots.md
@@ -65,6 +65,11 @@ robot.adapter.on 'connected', ->
 robot.run()
 ```
 
+Open questions to answer:
+
+- is there any need for the bin/hubot launcher? Perhaps it could be useful for handling some of the logistics of
+- should `loadScriptPackage` take a string to require, or expect a function? if it takes a function, that implies something that is more general
+
 ## Detailed design
 
 > Describe the design of the solution in detail. The detail in this section should be sufficient for someone who is *not* one of the authors to be able to reasonably implement the feature.

--- a/_drafts/programatically-configured-bots.md
+++ b/_drafts/programatically-configured-bots.md
@@ -99,3 +99,5 @@ Changing the constructor to use an Object of options would break compatibility. 
 > Describe alternative approaches to addressing the same problem, and why you chose this approach instead.
 
 Considered having the `bin/hubot` launcher interact with a `index.coffee` or `index.js`. It wasn't clear how that would work, and just running `index.coffee` or `index.js` makes more sense if you are familiar with running javascript projects.
+
+Considered adding properties to `Robot` for configuring script packages and script directories handled by `Robot#run`. This would take away much of the flexibility of being able to control load order.

--- a/_drafts/programatically-configured-bots.md
+++ b/_drafts/programatically-configured-bots.md
@@ -1,5 +1,5 @@
 ---
-state: In Progress
+state: In Review
 ---
 
 # Programmatic configuration of bots

--- a/_drafts/programatically-configured-bots.md
+++ b/_drafts/programatically-configured-bots.md
@@ -2,9 +2,9 @@
 state: In Progress
 ---
 
-# Progmatic configuration of bots
+# Programmatic configuration of bots
 
-A progmatically configured hubot would allow for developers to write a Javascript-VM-language-of-choice file to build their bot step-by-step, and have full control of the order of that scripts are loaded, in addition to allowing customizing express, the VM, etc.
+A programmatically configured hubot would allow for developers to write a index.coffee (or Javascript-VM-language-of-choice file) to build their bot step-by-step, and have full control of the order of that scripts are loaded, in addition to allowing customizing things like the built-in [expressjs](https://expressjs.com/) router and the nodejs VM.
 
 ## Motivation
 
@@ -13,7 +13,7 @@ The only way you can have hubot run your code is by having it in the `scripts`, 
 The current workaround is to name script files in a way that they are more likely to be loaded first. Consider:
 
 ```coffeescript
-# scripts/0-init.coffee
+# scripts/0-myawesomehelper.coffee
 module.exports = (robot) ->
   robot.myawesomehelper = () ->
     # insert awesome code here
@@ -23,11 +23,11 @@ module.exports = (robot) ->
   robot.myawesomehelper()
 ```
 
-There are some tools that need to be loaded as soon as possible to instrument as much as possible, such as NewRelic. There is no way currently to load that any sooner. [hubot#847](https://github.com/github/hubot/issues/847) is one example of this
+There are some tools that need to be loaded as soon as possible to instrument as much as possible, such as [New Relic](https://newrelic.com/). There is no way currently to load that any sooner. [hubot#847](https://github.com/github/hubot/issues/847) is one example of this.
 
-Hubot includes an instance of [expressjs](https://expressjs.com/) in it, for convenience in integrating with other services, and also because some adapters need it. Since it is a HTTP server, there are an infinite number of ways to configure it, and it is impossible to accomodate all of them. There have been a number of PRs and requests over the year to allow customization of some of its expressjs, and have involved adding an increasing number of environment variables to control the behavior. An experienced expressjs user coming onto hubot would not be able to customize the server in a way they would be used to. The specifics of allowing this are worth having its own evolution proposal, but a programatic launch of hubot would be a pre-requisite of it.
+Hubot includes an instance of [expressjs](https://expressjs.com/) in it, for convenience in integrating with other services, and also because some adapters need it. Since it is a HTTP server, there are an infinite number of ways to configure it, and it is impossible to accommodate all of them. There have been a number of PRs and requests over the year to allow customization of some of its expressjs, and have involved adding an increasing number of environment variables to control the behavior. An experienced expressjs user coming onto hubot would not be able to customize the server in a way they would be used to. The specifics of allowing this are worth having its own evolution proposal, but a programmatic launch of hubot would be a prerequisite of it.
 
-Lastly, there is a fair amount of scaffolding to get hubot running. Programatic launching of hubot would allow for a single-file example hubot. This would make for a great getting started example, and also obviate the need for a generator which has been progmatic in the past.
+Lastly, there is a fair amount of scaffolding to get hubot running. Programmatic launching of hubot would allow for a single-file example hubot. This would make for a great getting started example, and also obviate the need for a generator which has been programmatic in the past.
 
 
 ## Proposed solution
@@ -36,7 +36,35 @@ Lastly, there is a fair amount of scaffolding to get hubot running. Programatic 
 
 TODO
 
-- refactor `Robot` constructor to not use positional arguments
+```coffeescript
+Hubot   = require 'hubot'
+Log     = require 'log'
+Path    = require 'path'
+
+robot = new Hubot.Robot
+robot.logger = new Log('info')
+robot.adapter = new Hubot.BuiltinAdapters.Shell(robot)
+robot.alias = '/'
+
+# wait for adapter to be connected, since it might change things at runtime,
+# like robot name
+robot.adapter.on 'connected', ->
+
+  # require external hubot scripts
+  robot.loadScriptPackage require('hubot-help')
+  robot.loadScriptPackage require('hubot-shipit')
+
+  # load scripts from a local scripts directory
+  # NOTE you need to either specify NODE_PATH=. or Path.resolve a local directory for this to work
+  robot.load Path.resolve 'scripts'
+
+  # or do things them inline
+  robot.respond /ping/i, (res) ->
+    res.send 'PONG'
+
+# then run hubot
+robot.run()
+```
 
 ## Detailed design
 
@@ -48,15 +76,15 @@ TODO
   - https://github.com/github/hubot/pull/1110 is a start
 - update APIs to easier, more obvious how they work, etc when running from a single file
   - probably means `Robot` taking key/values, rather than positional
-   
+  - make arguments/options to `Robot` constructor optional, but validate required options when `run`ning
 
 ## Backward compatibility
 
 > Describe how this change affects compatibility with existing community packages. Will they break? Will they produce different behavior? If "yes" to either of these, is it possible to support the old behavior alongside the new behavior? Can scripts be written in a way that they work before and after this change?
 
-Changing the constructor to use an Object of options would break compatability. It should be possible to detect if the first argument is an Object to use the new style, or use the old positional arguments.
+Changing the constructor to use an Object of options would break compatibility. It should be possible to detect if the first argument is an Object to use the new style, or use the old positional arguments.
 
-`Robot`'s contrusctor might not even be a public API currently, but it's pretty likely something out there (test helpers?) use it in its current form.
+`Robot`'s constructor might not even be a public API currently, but it's pretty likely something out there (test helpers?) use it in its current form.
 
 ## Alternatives considered
 


### PR DESCRIPTION
A programmatically configured hubot would allow for developers to write a index.coffee (or Javascript-VM-language-of-choice file) to build their bot step-by-step. This would give fine-grained control of a Hubot instance, such as control of the script load order, customization of the built-in [Express](https://expressjs.com/) router, tuning and instrumentation of the Node.js VM.

```coffeescript
Hubot   = require 'hubot'
Log     = require 'log'
Path    = require 'path'

robot = new Hubot.Robot
robot.logger = new Log('info')
robot.adapter = new Hubot.BuiltinAdapters.Shell(robot)
robot.alias = '/'

# wait for adapter to connect, since it might change robot.name at runtime,
# like robot name
robot.adapter.on 'connected', ->

  # require external hubot scripts
  robot.loadScriptPackage require('hubot-help')
  robot.loadScriptPackage require('hubot-shipit')

  # load scripts from a local scripts directory
  # NOTE you need to either specify NODE_PATH=. or Path.resolve a local directory for this to work
  robot.load Path.resolve 'scripts'

  # or do things them inline
  robot.respond /ping/i, (res) ->
    res.send 'PONG'

# then run hubot
robot.run()
```

👀 **[read the proposal](https://github.com/hubotio/evolution/blob/2936e53d16c7e980b340bfaaa7c4241659480a04/_drafts/programatically-configured-bots.md)** 👀