### PR TITLE
Remove 3.0 version from goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,23 @@
 
 This repository tracks the ongoing evolution of [Hubot](https://github.com/github/hubot). It contains:
 
-* Goals for upcoming releases. Up next: [3.0](#hubot-3.0)
+* [Goals](#goals) for upcoming releases.
 * [Proposals](https://github.com/hubotio/evolution/projects/1) to change Hubot
 * The [process](CONTRIBUTING.md) that governs the evolution of Hubot.
 
-This document describes goals on a per-release basis, usually listing minor releases adding to the currently shipping version and one major release out. Each release will have many smaller features or changes independent of these larger goals, and not all goals are reached for each release.
+This document describes the high-level goals for the next couple months. Smaller features or changes independent of these larger goals will also be made, and some goals may not be reached.
 
-## Hubot 3.0
+## Goals
 
-Expected release date: Late 2017
+Hubot aims to be an automation framework optimized for developers and developer workflows, with great integration with the most popular chat clients and developer tools, and an active community that is sharing scripts and best practices.
 
-Hubot 3.0 aims to be an automation framework optimized for developers and developer workflows, with great integration with the most popular chat clients and developer tools, and an active community that is sharing scripts and best practices.
-
-On the path to Hubot 3.0, we will:
+The current focus is:
 
 1. Return the project to a “maintained” status by creating a core team, documenting all policies and processes, reviewing stale Issues and Pull Requests, and establishing a regular release cadence.
-2. Modernize the community by consolidating officially supported repositories into on GitHub organization, creating a place for users to get support and contributors to collaborate, improving contributor experience, and establishing this process for evolving Hubot going forward.
+2. Modernize the community by consolidating officially supported repositories into one GitHub organization, creating a place for users to get support and contributors to collaborate, improving contributor experience, and establishing this process for evolving Hubot going forward.
 3. Modernize the project by translating CoffeeScript to JavaScript, improving integration with various developer tools, and adding features that make it easier for developers to automate their workflow.
 
-The high-priority features for Hubot 3.0 are:
+The high-priority features for upcoming releases are:
 
 * **Commands**: an explicit interface for exposing discrete pieces of functionality as an alternative to regular expressions (like Slack’s slash commands), along with an RPC spec and implementation for exposing commands to and consuming commands from other services.
 


### PR DESCRIPTION
We will be switching to a more strict semantic versioning scheme and the path to these features will likely involve multiple major versions. This removes the "3.0" language from the README.

cc #6 